### PR TITLE
Improve capture generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   Obtiene información detallada (resolución, duración, peso, pistas, idiomas, canales, formato, etc.) usando `pymediainfo`.
 
 - 🖼️ **Capturas automáticas**  
-  Genera capturas de pantalla (JPG/PNG) en posiciones estratégicas usando `ffmpeg`, configurable en cantidad y porcentaje.
+  Genera capturas de pantalla en formato JPG en posiciones estratégicas usando `ffmpeg`, configurable en cantidad y porcentaje.
 
 - 📦 **Compresión RAR profesional**  
   Comprime cada video en su propio archivo RAR (con o sin compresión), soporta división automática y nombres limpios.


### PR DESCRIPTION
## Summary
- avoid parsing media info twice by passing duration into `generar_capturas`
- switch capture output to JPG and update messages
- remove unused imports and duplicate code
- fix spelling mistakes in summary panel
- update README accordingly

## Testing
- `python -m py_compile rar_folder_image_info.py`


------
https://chatgpt.com/codex/tasks/task_e_684fcac7d0e88326b7a825927f678d45